### PR TITLE
Added enable snippets flag for custom snippets in ingress configurations

### DIFF
--- a/nginx-ingress/hub-component.yaml
+++ b/nginx-ingress/hub-component.yaml
@@ -46,6 +46,8 @@ parameters:
     empty: allow
   - name: externalTrafficPolicy
     value: Cluster
+  - name: enableSnippets
+    value: true
 
 - name: helm
   parameters:

--- a/nginx-ingress/values.yaml.gotemplate
+++ b/nginx-ingress/values.yaml.gotemplate
@@ -11,7 +11,7 @@ controller:
   replicaCount: {{.nginx.replicaCount}}
   ingressClass: "{{.ingress.class}}"
   setAsDefaultIngress: {{.ingress.isDefault}}
-  enableSnippets: true
+  enableSnippets: {{.nginx.enableSnippets}}
   service:
     externalTrafficPolicy: "{{.nginx.externalTrafficPolicy}}" 
     type: "{{.nginx.serviceType}}" 

--- a/nginx-ingress/values.yaml.gotemplate
+++ b/nginx-ingress/values.yaml.gotemplate
@@ -11,6 +11,7 @@ controller:
   replicaCount: {{.nginx.replicaCount}}
   ingressClass: "{{.ingress.class}}"
   setAsDefaultIngress: {{.ingress.isDefault}}
+  enableSnippets: true
   service:
     externalTrafficPolicy: "{{.nginx.externalTrafficPolicy}}" 
     type: "{{.nginx.serviceType}}" 


### PR DESCRIPTION
Enabling this flag will allow users to use custom snippets in their ingress configurations (for example enable authorization)